### PR TITLE
fixed issue with refernce the 0th index of the z array

### DIFF
--- a/src/glm_aed2.F90
+++ b/src/glm_aed2.F90
@@ -937,7 +937,7 @@ SUBROUTINE calculate_fluxes(column, wlev, column_sed, nsed, flux_pel, flux_atm, 
       !# Disaggregation of zone induced fluxes to overlying layers
       v_start = 1 ; v_end = n_vars
       zon = n_zones
-      DO lev=wlev,1,-1
+      DO lev=wlev,2,-1
         IF ( zon .NE. 1 ) THEN
           splitZone = zz(lev-1) < zone_heights(zon-1)
         ELSE

--- a/src/glm_zones.F90
+++ b/src/glm_zones.F90
@@ -217,7 +217,7 @@ SUBROUTINE copy_from_zone(x_cc, x_diag, x_diag_hz, wlev)
    v_start = nvars+1 ; v_end = nvars+nbenv
 
    zon = n_zones
-   DO lev=wlev,1,-1
+   DO lev=wlev,2,-1
       IF ( zon .NE. 1 ) THEN
          splitZone = zz(lev-1) < zone_heights(zon-1)
       ELSE


### PR DESCRIPTION
I was getting segmentation faults randomly with AED turned on.  After looking into it, it appears that  the code was trying to use the 0th index of the heights array.  In some lucky runs zz(0) was set to zero but in unlucky runs zz(0) was not an integer - resulting in a sedimentation fault.   Since the code is looking down the heights it seems that it wants stop the DO loop at 2 so that the last time through it looks down to the bottom height (i.e., the one with 1th index).  